### PR TITLE
Fix caching bot message.

### DIFF
--- a/mirai-api-http/src/main/kotlin/net/mamoe/mirai/api/http/route/MessageRouteModule.kt
+++ b/mirai-api-http/src/main/kotlin/net/mamoe/mirai/api/http/route/MessageRouteModule.kt
@@ -104,7 +104,8 @@ fun Application.messageModule() {
                     is Incoming.FromTemp -> TempMessagePacketDto(MemberDTO(sender))
                 }
 
-                dto.messageChain = originalMessage.toMessageChainDTO { d -> d != UnknownMessageDTO }
+                dto.messageChain = messageChainOf(this, originalMessage)
+                    .toMessageChainDTO { d -> d != UnknownMessageDTO }
                 call.respondDTO(EventRestfulResult(
                     data = dto
                 ))


### PR DESCRIPTION
Fix #190 

Outgoing MessageSources are constructed without creating new chain containing itself. Considered as design for mirai-core.
