### PR TITLE
Set minimum JDK version to 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+assert org.gradle.api.JavaVersion.current().isJava11Compatible()
+
 buildscript {
     repositories {
         mavenLocal()
@@ -25,3 +27,4 @@ allprojects {
         mavenCentral()
     }
 }
+

--- a/mirai-api-http/build.gradle.kts
+++ b/mirai-api-http/build.gradle.kts
@@ -110,11 +110,11 @@ kotlin {
 
 val compileKotlin: org.jetbrains.kotlin.gradle.tasks.KotlinCompile by tasks
 compileKotlin.kotlinOptions {
-    jvmTarget = "11"
+    jvmTarget = "1.8"
 }
 val compileTestKotlin: org.jetbrains.kotlin.gradle.tasks.KotlinCompile by tasks
 compileTestKotlin.kotlinOptions {
-    jvmTarget = "11"
+    jvmTarget = "1.8"
 }
 
 project.version = httpVersion

--- a/mirai-api-http/build.gradle.kts
+++ b/mirai-api-http/build.gradle.kts
@@ -110,11 +110,11 @@ kotlin {
 
 val compileKotlin: org.jetbrains.kotlin.gradle.tasks.KotlinCompile by tasks
 compileKotlin.kotlinOptions {
-    jvmTarget = "1.8"
+    jvmTarget = "11"
 }
 val compileTestKotlin: org.jetbrains.kotlin.gradle.tasks.KotlinCompile by tasks
 compileTestKotlin.kotlinOptions {
-    jvmTarget = "1.8"
+    jvmTarget = "11"
 }
 
 project.version = httpVersion


### PR DESCRIPTION
This resolves the issue #198.

An interesting note is that Java 11 is required only by `mirai-api-http/build.gradle.kts` (i.e. the sub-project build script). After compiling the build script with Java 11, it is possible to build the project with Java 8 (which was specified in the build script).

Nevertheless, it still might be worthy to have a clear and concise error message than an obscure one.
