### PR TITLE
修正 peekMessage 接口的拼写错误

### DIFF
--- a/mirai-api-http/src/main/kotlin/net/mamoe/mirai/api/http/adapter/http/router/message.kt
+++ b/mirai-api-http/src/main/kotlin/net/mamoe/mirai/api/http/adapter/http/router/message.kt
@@ -47,6 +47,12 @@ internal fun Application.messageRouter() = routing {
         call.respondDTO(EventListRestfulResult(data = data))
     }
 
+    /*兼容旧接口*/
+    httpAuthedGet<CountDTO>("/peakMessage") {
+        val data = it.unreadQueue.peek(it.count)
+        call.respondDTO(EventListRestfulResult(data = data))
+    }
+    
     /**
      * 获取指定条数最新的消息，和 `/fetchLatestMessage` 不一样，这个方法不会删除消息
      */

--- a/mirai-api-http/src/main/kotlin/net/mamoe/mirai/api/http/adapter/http/router/message.kt
+++ b/mirai-api-http/src/main/kotlin/net/mamoe/mirai/api/http/adapter/http/router/message.kt
@@ -42,7 +42,7 @@ internal fun Application.messageRouter() = routing {
     /**
      * 获取指定条数最老的消息，和 `/fetchMessage` 不一样，这个方法不会删除消息
      */
-    httpAuthedGet<CountDTO>("/peakMessage") {
+    httpAuthedGet<CountDTO>("/peekMessage") {
         val data = it.unreadQueue.peek(it.count)
         call.respondDTO(EventListRestfulResult(data = data))
     }


### PR DESCRIPTION
http adapter 中，peekMessage 被误拼写为 peakMessage。