### PR TITLE
使更新命令兼容Linux Bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Mirai HTTP API (console) plugin
 
 * `MCL` 支持自动更新插件，支持设置插件更新频道等功能
 
-`.\mcl --update-package net.mamoe:mirai-api-http --channel stable --type plugin`
+`./mcl --update-package net.mamoe:mirai-api-http --channel stable --type plugin`
 
 ### 手动安装`mirai-api-http`
 


### PR DESCRIPTION
README.md 中通过MCL安装的命令使用'\'而不是'/'。修改后兼容Linux Bash。