### PR TITLE
fix: yaml cors should be surrounded by ""

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ adapterSettings:
   http:
     host: localhost
     port: 8080
-    cors: [*]
+    cors: ["*"]
   
   ## 详情看 websocket adapter 使用说明 配置
   ws:


### PR DESCRIPTION
标准的 YAML 语法，应该使用引号包裹数组内的字符串。